### PR TITLE
Make plugin consumable by other plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.479</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
 
     <spotless.check.skip>false</spotless.check.skip>
@@ -44,7 +44,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4545.v56392b_7ca_7b_a_</version>
+        <version>5054.v620b_5d2b_d5e6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/CronTabWrapper.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/CronTabWrapper.java
@@ -1,29 +1,30 @@
 package io.jenkins.plugins.extended_timer_trigger;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.scheduler.CronTab;
 import hudson.scheduler.CronTabList;
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Map;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
-@Restricted(NoExternalUse.class)
 public class CronTabWrapper {
 
-  private final CronTabList cronTab;
+  private final CronTabList cronTabList;
+  private final CronTab cronTab;
   private final ExtendedCronTab extendedCronTab;
   private Map<String, String> parameters;
 
-  public CronTabWrapper(CronTabList cronTab) {
-    this.cronTab = cronTab;
+  public CronTabWrapper(CronTabList cronTabList, CronTab cronTab) {
+    this.cronTabList = cronTabList;
     this.extendedCronTab = null;
+    this.cronTab = cronTab;
   }
 
   public CronTabWrapper(ExtendedCronTab extendedCronTab) {
     this.extendedCronTab = extendedCronTab;
+    this.cronTabList = null;
     this.cronTab = null;
   }
 
@@ -37,9 +38,9 @@ public class CronTabWrapper {
   }
 
   public boolean check(ZonedDateTime time) {
-    if (cronTab != null) {
+    if (cronTabList != null) {
       Calendar cal = GregorianCalendar.from(time);
-      return cronTab.check(cal);
+      return cronTabList.check(cal);
     } else {
       if (extendedCronTab != null) {
         return extendedCronTab.check(time);
@@ -51,8 +52,8 @@ public class CronTabWrapper {
   @CheckForNull
   @SuppressRestrictedWarnings(CronTabList.class)
   public ZonedDateTime previous() {
-    if (cronTab != null) {
-      Calendar scheduled = cronTab.previous();
+    if (cronTabList != null) {
+      Calendar scheduled = cronTabList.previous();
       if (scheduled != null) {
         return ZonedDateTime.ofInstant(scheduled.toInstant(), scheduled.getTimeZone().toZoneId());
       }
@@ -64,10 +65,11 @@ public class CronTabWrapper {
     return null;
   }
 
+  @CheckForNull
   @SuppressRestrictedWarnings(CronTabList.class)
   public ZonedDateTime next() {
-    if (cronTab != null) {
-      Calendar scheduled = cronTab.next();
+    if (cronTabList != null) {
+      Calendar scheduled = cronTabList.next();
       if (scheduled != null) {
         return ZonedDateTime.ofInstant(scheduled.toInstant(), scheduled.getTimeZone().toZoneId());
       }
@@ -80,9 +82,35 @@ public class CronTabWrapper {
   }
 
   @CheckForNull
-  public String checkSanity() {
+  public ZonedDateTime ceil(long timeInMillis) {
     if (cronTab != null) {
-      return cronTab.checkSanity();
+      Calendar scheduled = cronTab.ceil(timeInMillis);
+      return ZonedDateTime.ofInstant(scheduled.toInstant(), scheduled.getTimeZone().toZoneId());
+    } else {
+      if (extendedCronTab != null) {
+        return extendedCronTab.ceil(timeInMillis);
+      }
+    }
+    return null;
+  }
+
+  @CheckForNull
+  public ZonedDateTime floor(long timeInMillis) {
+    if (cronTab != null) {
+      Calendar scheduled = cronTab.floor(timeInMillis);
+      return ZonedDateTime.ofInstant(scheduled.toInstant(), scheduled.getTimeZone().toZoneId());
+    } else {
+      if (extendedCronTab != null) {
+        return extendedCronTab.floor(timeInMillis);
+      }
+    }
+    return null;
+  }
+
+  @CheckForNull
+  public String checkSanity() {
+    if (cronTabList != null) {
+      return cronTabList.checkSanity();
     }
     return null;
   }

--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
@@ -6,6 +6,7 @@ import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.model.time.ExecutionTime;
 import com.cronutils.parser.CronParser;
 import hudson.scheduler.Hash;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.regex.Matcher;
@@ -96,8 +97,26 @@ public class ExtendedCronTab {
     return ExecutionTime.forCron(cron).nextExecution(time).orElse(null);
   }
 
+  public ZonedDateTime ceil(long timeInMillis) {
+    Instant instant = Instant.ofEpochMilli(timeInMillis);
+    ZonedDateTime time = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+    if (zoneId != null) {
+      time = time.withZoneSameInstant(zoneId);
+    }
+    return ExecutionTime.forCron(cron).nextExecution(time).orElse(null);
+  }
+
   public ZonedDateTime previous() {
     ZonedDateTime time = ZonedDateTime.now();
+    if (zoneId != null) {
+      time = time.withZoneSameInstant(zoneId);
+    }
+    return ExecutionTime.forCron(cron).lastExecution(time).orElse(null);
+  }
+
+  public ZonedDateTime floor(long timeInMillis) {
+    Instant instant = Instant.ofEpochMilli(timeInMillis);
+    ZonedDateTime time = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
     if (zoneId != null) {
       time = time.withZoneSameInstant(zoneId);
     }

--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedTimerTrigger.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedTimerTrigger.java
@@ -35,8 +35,6 @@ import jenkins.model.Jenkins;
 import jenkins.triggers.TriggeredItem;
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -46,7 +44,6 @@ import org.kohsuke.stapler.verb.POST;
 /**
  * Trigger that runs a job periodically.
  */
-@Restricted(NoExternalUse.class)
 public class ExtendedTimerTrigger extends Trigger<Job<?, ?>> {
 
   private static final Logger LOGGER = Logger.getLogger(ExtendedTimerTrigger.class.getName());
@@ -62,6 +59,10 @@ public class ExtendedTimerTrigger extends Trigger<Job<?, ?>> {
 
   public String getCronSpec() {
     return cronSpec;
+  }
+
+  public ExtendedCronTabList getExtendedCronTabList() {
+    return extendedCronTabList;
   }
 
   @Override


### PR DESCRIPTION
calendar-view and next-executions plugins allow to show coming executions. To be able to integrate into those plugins the classes must be consumable by them. 
- remove the restrictions 
- and add floor/ceil methods as used in calendar-view.


<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
