### PR TITLE
add method that returns next CronTabWrapper

### DIFF
--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTabList.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTabList.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.kohsuke.accmod.restrictions.suppressions.SuppressRestrictedWarnings;
 
 public class ExtendedCronTabList {
 
@@ -47,7 +46,6 @@ public class ExtendedCronTabList {
   }
 
   @CheckForNull
-  @SuppressRestrictedWarnings(CronTabList.class)
   public ZonedDateTime previous() {
     ZonedDateTime previous = null;
     for (CronTabWrapper wrapper: cronTabWrapperList) {
@@ -60,7 +58,6 @@ public class ExtendedCronTabList {
   }
 
   @CheckForNull
-  @SuppressRestrictedWarnings(CronTabList.class)
   public ZonedDateTime next() {
     ZonedDateTime next = null;
     for (CronTabWrapper wrapper: cronTabWrapperList) {
@@ -70,6 +67,26 @@ public class ExtendedCronTabList {
       }
     }
     return next;
+  }
+
+  /**
+   * The next CronTabWrapper to be triggered.
+   * If 2 triggers are scheduled for the same time, only the first one
+   * that is specified in the spec is returned.
+   * @return
+   */
+  @CheckForNull
+  public CronTabWrapper nextCronTabWrapper() {
+    CronTabWrapper nextCronTab = null;
+    ZonedDateTime next = null;
+    for (CronTabWrapper wrapper: cronTabWrapperList) {
+      ZonedDateTime scheduled = wrapper.next();
+      if (next == null || (scheduled != null && next.isAfter(scheduled))) {
+        nextCronTab = wrapper;
+        next = scheduled;
+      }
+    }
+    return nextCronTab;
   }
 
   @CheckForNull


### PR DESCRIPTION
With the new method one can get the next execution for a project including the parameters

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
