### PR TITLE
fix calcluation for bounds of H

### DIFF
--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
@@ -31,7 +31,7 @@ public class ExtendedCronTab {
   private static final int[] UPPER_BOUNDS = new int[] {59, 23, 28, 12, 6};
   private static final String[] FIELD_NAMES = new String[] {"Minute", "Hour", "Day-of-Month", "Month", "Day-of-Week"};
 
-  private static final Pattern pattern = Pattern.compile("^H\\((\\d)+-(\\d+)\\)$");
+  private static final Pattern pattern = Pattern.compile("^H\\((\\d+)-(\\d+)\\)$");
 
   private final Cron cron;
   private final ZoneId zoneId;
@@ -62,7 +62,7 @@ public class ExtendedCronTab {
     int lowerBound = LOWER_BOUNDS[field];
     int upperBound = UPPER_BOUNDS[field];
     if (tokens[field].equals("H")) {
-      tokens[field] = String.valueOf(hash.next(upperBound) + lowerBound);
+      tokens[field] = String.valueOf(hash.next(upperBound + 1 - lowerBound) + lowerBound);
       return;
     }
     Matcher m = pattern.matcher(tokens[field]);


### PR DESCRIPTION
For `H` the upper bound was 1 too low, so it would only return values from 0 to 58 for minute or seconds
For `H(10-20)` it would calculate in the range 1-20 only taking the first digit of the lower bound

fixes #49

<!-- Please describe your pull request here. -->

### Testing done
Manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
