### PR TITLE
Add support for all hash patterns like H/4 and H(0-29)/5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 
 This plugin adds another timer based trigger to jobs. It has an extended syntax that allows for better scheduling of weekly or monthly triggers. 
-It also allows to define the timezone multiple times in the list and you can specify parameters to be passed for executions.
+It also allows to define the timezone multiple times in the list, and you can specify parameters to be passed for executions.
 
 ## Getting started
 
@@ -18,7 +18,7 @@ You can add one or more cron like entries with the 5 fields
 You can use the same syntax as for the Jenkins provided `Build periodically` but also an extended syntax to e.g. run a job on the last 
 day of a month, or only on the second Tuesday, or on the last weekday.
 
-In the extended syntax the special character `H` has limited support. It can only be used standalone or in combination with a range e.g. *H(0-4)*
+In the extended syntax the special character `H` has the same meaning as in the Jenkins provided `Build periodically` trigger and behaves the same as in the Jenkins provided `Build periodically` trigger. It stands for a random value (based on the hash of the job name) and is used to spread out load evenly.
 
 ### Fields 
 
@@ -43,7 +43,7 @@ In the extended syntax the special character `H` has limited support. It can onl
 | L     | Short for "last" and can be used in the Day-of-Month and Day-of-Week fields. The <em>L</em> character has a different meaning in the two fields. In the Day-of-Month field, it means the last day of the month. In the Day-of-Week field, it means 6 or SAT. If used in the Day-of-Week field after a number, it means the last xxx day of the month. E.g., <em>6L</em> in the Day-of-Week field means the last Saturday of the month. |
 | W     | Stands for "weekday" and is only allowed for the Day-of-Month field. The <em>W</em> character is used to specify the weekday nearest to the given day. E.g., <em>10W</em> in the Day-of-Month field means the nearest weekday to the 10th of the month. If the 10th is a Saturday, the job will run on Friday the 10th. <em>W</em> can be combined with <em>L</em> to <em>LW</em> and means last weekday of the month.                 |
 | #     | Can only be used in the Day-of-Week field. Used to specify constructs. E.g., <em>5#3</em> means the third Friday of the month.                                                                                                                                                                                                                                                                                                         |
-| H     | Stands for a random value (based on the hash of the job name). Must be used standalone or in combination with a range e.g. *H(0-4)*. In the Day-of-Month field values are chosen in the 1-28 range.                                                                                                                                                                                                                                    |
+| H     | Stands for a random value (based on the hash of the job name). Must be used standalone or in combination with a range e.g. *H(0-4)*, *H(0-29)/5* or *H/15*. In the Day-of-Month field values are chosen in the 1-28 range.                                                                                                                                                                                                             |
 ### Parameters
 To define parameters that should be passed to a schedule start the next line with a `%` followed by `name=value`.
 If you want to have a parameter take a multiline value prefix the next line with `%%`. For better readability you might want to indent the parameter definitions. Each line after the cron spec that starts with `%` is interpreted as parameter until a new cron spec or timezone definition is found.

--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
@@ -31,7 +31,7 @@ public class ExtendedCronTab {
   private static final int[] UPPER_BOUNDS = new int[] {59, 23, 28, 12, 6};
   private static final String[] FIELD_NAMES = new String[] {"Minute", "Hour", "Day-of-Month", "Month", "Day-of-Week"};
 
-  private static final Pattern pattern = Pattern.compile("^H\\((\\d)+-(\\d+)\\)$");
+  private static final Pattern pattern = Pattern.compile("^H\\((\\d+)-(\\d+)\\)$");
 
   private final Cron cron;
   private final ZoneId zoneId;
@@ -62,7 +62,7 @@ public class ExtendedCronTab {
     int lowerBound = LOWER_BOUNDS[field];
     int upperBound = UPPER_BOUNDS[field];
     if (tokens[field].equals("H")) {
-      tokens[field] = String.valueOf(hash.next(upperBound) + lowerBound);
+      tokens[field] = String.valueOf(hash.next(upperBound + 1 - lowerBound) + lowerBound);
       return;
     }
     Matcher m = pattern.matcher(tokens[field]);

--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedCronTab.java
@@ -31,7 +31,8 @@ public class ExtendedCronTab {
   private static final int[] UPPER_BOUNDS = new int[] {59, 23, 28, 12, 6};
   private static final String[] FIELD_NAMES = new String[] {"Minute", "Hour", "Day-of-Month", "Month", "Day-of-Week"};
 
-  private static final Pattern pattern = Pattern.compile("^H\\((\\d+)-(\\d+)\\)$");
+  private static final Pattern rangePattern = Pattern.compile("^H\\((\\d+)-(\\d+)\\)(/(-?\\d+))?$");
+  private static final Pattern stepPattern = Pattern.compile("^H/(\\d+)$");
 
   private final Cron cron;
   private final ZoneId zoneId;
@@ -65,22 +66,58 @@ public class ExtendedCronTab {
       tokens[field] = String.valueOf(hash.next(upperBound + 1 - lowerBound) + lowerBound);
       return;
     }
-    Matcher m = pattern.matcher(tokens[field]);
+    Matcher m = rangePattern.matcher(tokens[field]);
     if (m.matches()) {
       int lower = Integer.parseInt(m.group(1));
       int upper = Integer.parseInt(m.group(2));
-      if (lower < lowerBound) {
-        throw new IllegalArgumentException(Messages.ExtendedCronTab_OutOfRange(lower, lowerBound, upperBound, FIELD_NAMES[field]));
+      int step = 1;
+      String stepStr = m.group(4);
+      if (stepStr != null) {
+        step = Integer.parseInt(m.group(4));
       }
-      if (upper > upperBound) {
-        throw new IllegalArgumentException(Messages.ExtendedCronTab_OutOfRange(upper, lowerBound, upperBound, FIELD_NAMES[field]));
-      }
-      if (lower > upper) {
-        throw new IllegalArgumentException(Messages.ExtendedCronTab_LowerUpper(lower, upper));
-      }
-      tokens[field] = String.valueOf(hash.next(upper + 1 - lower) + lower);
+      String unhashed = hashToString(lower, upper, step, field, hash);
+      tokens[field] = unhashed;
+      return;
+    }
+    m = stepPattern.matcher(tokens[field]);
+    if (m.matches()) {
+      int step = Integer.parseInt(m.group(1));
+      String unhashed = hashToString(lowerBound, upperBound, step, field, hash);
+      tokens[field] = unhashed;
     }
   }
+
+  private String hashToString(int lower, int upper, int step, int field, Hash hash) {
+    rangeCheck(lower, field);
+    rangeCheck(upper, field);
+    StringBuilder builder = new StringBuilder();
+    if (lower > upper) {
+      throw new IllegalArgumentException(Messages.ExtendedCronTab_LowerUpper(lower, upper));
+    }
+    if (step > upper - lower + 1) {
+      throw new IllegalArgumentException(Messages.ExtendedCronTab_OutOfRange(step, 1, upper - lower + 1, FIELD_NAMES[field]));
+    } else if (step > 1) {
+      for (int i = hash.next(step) + lower; i <= upper; i += step) {
+        if (!builder.isEmpty()) {
+          builder.append(",");
+        }
+        builder.append(i);
+      }
+      return builder.toString();
+    } else if (step <= 0) {
+      throw new IllegalArgumentException(Messages.ExtendedCronTab_MustBePositive(step));
+    } else {
+      // step=1 (i.e. omitted) in the case of hash is actually special; means pick one value, not step by 1
+      return Integer.toString(lower + hash.next(upper + 1 - lower));
+    }
+  }
+
+  protected void rangeCheck(int value, int field) {
+    if (value < LOWER_BOUNDS[field] || UPPER_BOUNDS[field] < value) {
+      throw new IllegalArgumentException(Messages.ExtendedCronTab_OutOfRange(value, LOWER_BOUNDS[field], UPPER_BOUNDS[field], FIELD_NAMES[field]));
+    }
+  }
+
 
   public boolean check(ZonedDateTime time) {
     if (zoneId != null) {

--- a/src/main/resources/io/jenkins/plugins/extended_timer_trigger/ExtendedTimerTrigger/help-cronSpec.html
+++ b/src/main/resources/io/jenkins/plugins/extended_timer_trigger/ExtendedTimerTrigger/help-cronSpec.html
@@ -1,7 +1,10 @@
 <div>
   Trigger runs based on a cron like schedule. You can use the regular Jenkins syntax but also an extended syntax.
   See the tables below for reference.<br/>
-  The extended syntax has limited support for the <b>H</b> character. It can only be used standalone and not in combination with ranges or intervals.<br/>
+  In the extended syntax the special character `H` has the same meaning as in the Jenkins provided `Build periodically` trigger
+  and behaves the same as in the Jenkins provided `Build periodically` trigger. It stands for a random value
+  (based on the hash of the job name) and is used to spread out load evenly.
+
   <br/>
   <b>Timezone</b><br/>
   To specify a different timezone use
@@ -125,8 +128,8 @@
       </tr>
       <tr>
         <td>H</td>
-        <td>Stands for a random value (based on the hash of the job name). Must be used standalone or in combination with a range e.g. <em>H(0-4)</em>.
-        In the Day-of-Month field values are chosen in the 1-28 range.</td>
+        <td>Stands for a random value (based on the hash of the job name). Must be used standalone or in combination with a range e.g. *H(0-4)*,
+          *H(0-29)/5* or *H/15*. In the Day-of-Month field values are chosen in the 1-28 range.</td>
       </tr>
     </tbody>
   </table>

--- a/src/main/resources/io/jenkins/plugins/extended_timer_trigger/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/extended_timer_trigger/Messages.properties
@@ -4,3 +4,4 @@ ExtendedTimerTrigger.would_last_have_run_at_would_next_run_at=Would last have ru
 ExtendedTimerTriggerTimerTrigger.ExtendedTimerTriggerCause.ShortDescription=Started by timer with extended syntax
 ExtendedCronTab.OutOfRange={0} is an invalid value in field "{3}". Must be within {1} and {2}
 ExtendedCronTab.LowerUpper=Did you mean {1}-{0}?
+ExtendedCronTab.MustBePositive=Step must be positive, but found {0}


### PR DESCRIPTION
Add support for `H/s` and `H(x-y)/s`. This works identical to how core handles `H`

### Testing done
Manual testing

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
