### PR TITLE
Fix rare date handling

### DIFF
--- a/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedTimerTrigger.java
+++ b/src/main/java/io/jenkins/plugins/extended_timer_trigger/ExtendedTimerTrigger.java
@@ -16,6 +16,7 @@ import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.PeriodicWork;
 import hudson.scheduler.Hash;
+import hudson.scheduler.RareOrImpossibleDateException;
 import hudson.triggers.TimerTrigger;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
@@ -119,18 +120,34 @@ public class ExtendedTimerTrigger extends Trigger<Job<?, ?>> {
     }
 
     private void updateValidationsForNextRun(Collection<FormValidation> validations, ExtendedCronTabList ectl) {
-      ZonedDateTime prev = ectl.previous();
-      ZonedDateTime next = ectl.next();
-      if (prev != null && next != null) {
-        Locale locale = Stapler.getCurrentRequest2() != null
-            ? Stapler.getCurrentRequest2().getLocale()
-            : Locale.getDefault();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm zzz", locale);
-        validations.add(FormValidation.ok(Messages.ExtendedTimerTrigger_would_last_have_run_at_would_next_run_at(prev.format(formatter), next.format(formatter))));
-      } else {
-        validations.add(FormValidation.warning(Messages.ExtendedTimerTrigger_no_schedules_so_will_never_run()));
+      try {
+        ZonedDateTime prev = ectl.previous();
+        ZonedDateTime next = ectl.next();
+        if (prev != null && next != null) {
+          Locale locale = Stapler.getCurrentRequest2() != null
+              ? Stapler.getCurrentRequest2().getLocale()
+              : Locale.getDefault();
+          DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE, d MMM yyyy HH:mm zzz", locale);
+          validations.add(FormValidation.ok(Messages.ExtendedTimerTrigger_would_last_have_run_at_would_next_run_at(prev.format(formatter), next.format(formatter))));
+          checkRareDate(prev, next, validations);
+        } else {
+          validations.add(FormValidation.warning(Messages.ExtendedTimerTrigger_no_schedules_so_will_never_run()));
+        }
+      } catch (RareOrImpossibleDateException ex) {
+        validations.add(FormValidation.warning(Messages.ExtendedTimerTrigger_rare_or_impossible()));
       }
     }
+
+    private void checkRareDate(@NonNull ZonedDateTime prev, @NonNull ZonedDateTime next, Collection<FormValidation> validations) {
+      ZonedDateTime now = ZonedDateTime.now();
+      now.withZoneSameInstant(next.getZone());
+      ZonedDateTime plusTwoYears = now.plusYears(2);
+      ZonedDateTime minusTwoYears = now.minusYears(2);
+      if (prev.isBefore(minusTwoYears) || next.isAfter(plusTwoYears)) {
+        validations.add(FormValidation.warning(Messages.ExtendedTimerTrigger_rare()));
+      }
+    }
+
   }
 
   private List<ParameterValue> configureParameterValues(Map<String, String> parameterValues) {

--- a/src/main/resources/io/jenkins/plugins/extended_timer_trigger/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/extended_timer_trigger/Messages.properties
@@ -2,6 +2,9 @@ ExtendedTimerTrigger.DisplayName=Build periodically with extended Syntax
 ExtendedTimerTrigger.no_schedules_so_will_never_run=No schedules so will never run
 ExtendedTimerTrigger.would_last_have_run_at_would_next_run_at=Would last have run at {0}; would next run at {1}.
 ExtendedTimerTriggerTimerTrigger.ExtendedTimerTriggerCause.ShortDescription=Started by timer with extended syntax
+ExtendedTimerTrigger.rare=The schedule will match dates only rarely (e.g. Feb. 29th or Sunday, June 30th).
+ExtendedTimerTrigger.rare_or_impossible=The schedule will match dates only rarely (e.g. Feb. 29th) or never (e.g. April 31st).
 ExtendedCronTab.OutOfRange={0} is an invalid value in field "{3}". Must be within {1} and {2}
 ExtendedCronTab.LowerUpper=Did you mean {1}-{0}?
 ExtendedCronTab.MustBePositive=Step must be positive, but found {0}
+


### PR DESCRIPTION
fixes #53

When a rare date is entered e.g. Feb 29th ensure we catch the exception thrown by core when using a regular Jenkins compatible schedule.

When using an extended pattern that is a valid date but rare, show the next execution and a warning.

<!-- Please describe your pull request here. -->

### Testing done
Interactive testing with various dates both regular and extended syntax no longer throws any exceptions and a proper warning is shown for rare dates

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
